### PR TITLE
Support input and output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ To build it, we need extra dependencies namely bcc-devel and kernel-headers for 
 
 Interface:
 
-```
-sudo podman run --annotation io.containers.trace-syscall=[absolute path to the json file] IMAGE COMMAND
+```bash
+sudo podman run --annotation io.containers.trace-syscall="if:[absolute path to the input file];of:[absolute path to the output file]" IMAGE COMMAND
 ```
 
-The profile will be created at the path provided to the annotation.
+The profile will be created at the output path provided to the annotation. Providing `of:` is mandatory, while `if:` is optional. An input file can be used to create a baseline and newly recorded syscalls will be added to the set and written to the output. If a syscall is blocked in the base profile, then it will remain blocked in the output file even if it is recorded while tracing.

--- a/docs/oci-seccomp-bpf-hook.md
+++ b/docs/oci-seccomp-bpf-hook.md
@@ -24,10 +24,10 @@ To build it, we need dependencies namely bcc-devel and kernel-headers for Fedora
 Interface:
 
 ```
-sudo podman run --annotation io.containers.trace-syscall=[absolute path to the json file] IMAGE COMMAND
+sudo podman run --annotation io.containers.trace-syscall="if:[absolute path to the input file];of:[absolute path to the output file]" IMAGE COMMAND
 ```
 
-The profile will be created at the path provided to the annotation.
+The profile will be created at the output path provided to the annotation. An input file can be used to create a baseline and newly recorded syscalls will be added to the set and written to the output. If a syscall is blocked in the base profile, then it will remain blocked in the output file even if it is recorded while tracing.
 
 ## FILES
 

--- a/oci-seccomp-bpf-hook-run.json
+++ b/oci-seccomp-bpf-hook-run.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "hook": {
-	"path": "HOOK_BIN_DIR/oci-seccomp-bpf-hook",
+        "path": "HOOK_BIN_DIR/oci-seccomp-bpf-hook",
         "args": [
             "oci-seccomp-bpf-hook",
             "-s"
@@ -16,3 +16,4 @@
         "prestart"
     ]
 }
+

--- a/oci-seccomp-bpf-hook_test.go
+++ b/oci-seccomp-bpf-hook_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseAnnotation(t *testing.T) {
+	testProfile := types.Seccomp{}
+	testProfile.DefaultAction = types.ActErrno
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "input-*.json")
+	if err != nil {
+		t.Fatalf("cannot create temporary file")
+	}
+	defer os.Remove(tmpFile.Name())
+	testProfileByte, err := json.Marshal(testProfile)
+	if err != nil {
+		t.Fatalf("cannot marshal json")
+	}
+
+	if _, err := tmpFile.Write(testProfileByte); err != nil {
+		t.Fatalf("cannot write to the temporary file")
+	}
+
+	for _, c := range []struct {
+		annotation, input, output string
+	}{
+		{"if:" + tmpFile.Name() + ";of:/home/test/output.json", tmpFile.Name(), "/home/test/output.json"},
+		{"of:/home/test/output.json", "", "/home/test/output.json"},
+		{"of:/home/test/output.json;if:" + tmpFile.Name(), tmpFile.Name(), "/home/test/output.json"},
+	} {
+		output, input, err := parseAnnotation(c.annotation)
+		assert.Nil(t, err)
+		assert.Equal(t, c.input, input)
+		assert.Equal(t, c.output, output)
+	}
+
+	// test malformed annotations
+	for _, c := range []string{
+		"if:/home/test/input1.json;if:/home/test/input2.json;of:/home/test/output.json",
+		"if:" + tmpFile.Name(),
+		"if:input;of:/home/test/output.json",
+		"if:" + tmpFile.Name() + ";of:output",
+	} {
+		_, _, err := parseAnnotation(c)
+		assert.NotNil(t, err)
+	}
+}

--- a/test/00-simple.bats
+++ b/test/00-simple.bats
@@ -24,7 +24,7 @@ load helpers
 	tmpFile=$(mktemp)
 	echo "Temporary file: ${tmpFile}"
 
-	run podman run --net=host --annotation io.containers.trace-syscall=${tmpFile} ${ALPINE} ls
+	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 	# sleep two seconds to let the hook finish writing the file
@@ -42,7 +42,7 @@ load helpers
 	tmpFile=$(mktemp)
 	echo "Temporary file: ${tmpFile}"
 
-	run podman run --net=host --annotation io.containers.trace-syscall=${tmpFile} ${ALPINE} ls
+	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 	# sleep two seconds to let the hook finish writing the file
@@ -54,4 +54,93 @@ load helpers
 
 	run podman run --net=host --security-opt seccomp=${tmpFile} alpine ls
 	[ "$status" -eq 0 ]
+}
+
+@test "Containers fails to run blocked syscall"{
+	local tmpFile
+	local size
+
+	tmpFile=$(mktemp)
+	echo "Temporary file: ${tmpFile}"
+
+	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
+	echo "Podman output: ${lines[*]}"
+	[ "$status" -eq 0 ]
+	# sleep two seconds to let the hook finish writing the file
+	sleep 2
+
+	size=$(du -b ${tmpFile} | awk '{ print $1 }')
+	echo "Size of generated file: ${size}"
+	[ "${size}" -gt 0 ]
+
+	run podman run --net=host --security-opt seccomp=${tmpFile} alpine sync
+	[ "$status" -ne 0 ]
+}
+
+@test "Extend existing seccomp profile"{
+	local tmpFile1
+	local tmpFile2
+	local size 
+
+	tmpFile1=$(mktemp)
+	tmpFile2=$(mktemp)
+	echo "Temporary file 1: ${tmpFile1}"
+	echo "Temporary file 2: ${tmpFile2}"
+
+	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile1} ${ALPINE} ls /
+	[ "$status" -eq 0 ]
+	# sleep two seconds to let the hook finish writing the file
+	sleep 2
+
+	size=$(du -b ${tmpFile1} | awk '{ print $1 }')
+	echo "Size of the first generated file: ${size}"
+	[ "${size}" -gt 0 ]
+
+	run podman run --net=host --security-opt seccomp=${tmpFile1} alpine ping -c3 google.com
+	[ "$status" -ne 0 ]
+
+	run podman run --net=host --annotation io.containers.trace-syscall="if:${tmpFile1};of:${tmpFile2}" ${ALPINE} ping -c3 google.com
+	[ "$status" -eq 0 ]
+	sleep 2
+
+	size=$(du -b ${tmpFile2} | awk '{ print $1 }')
+	echo "Size of the second generated file: ${size}"
+	[ "${size}" -gt 0 ]
+
+	run podman run --net=host --security-opt seccomp=${tmpFile2} alpine ls /
+	[ "$status" -eq 0 ]
+
+	run podman run --net=host --security-opt seccomp=${tmpFile2} alpine ping -c3 google.com
+	[ "$status" -eq 0 ]
+}
+
+@test "syscall blocked in input profile remains blocked in output profile"{
+	local tmpFile
+	local size 
+
+	tmpFile=$(mktemp)
+	echo "Temporary file : ${tmpFile}"
+
+	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} mkdir /foo
+	[ "$status" -eq 0 ]
+	# sleep two seconds to let the hook finish writing the file
+	sleep 2
+
+	size=$(du -b ${tmpFile} | awk '{ print $1 }')
+	echo "Size of the first generated file: ${size}"
+	[ "${size}" -gt 0 ]
+
+	run podman run --net=host --security-opt seccomp=${tmpFile} alpine mkdir /foo
+	[ "$status" -eq 0 ]
+
+	run podman run --net=host --annotation io.containers.trace-syscall="if:${BLOCK_MKDIR};of:${tmpFile}" ${ALPINE} mkdir /foo
+	[ "$status" -eq 0 ]
+	sleep 2
+
+	size=$(du -b ${tmpFile} | awk '{ print $1 }')
+	echo "Size of the second generated file: ${size}"
+	[ "${size}" -gt 0 ]
+
+	run podman run --net=host --security-opt seccomp=${tmpFile} alpine mkdir /foo
+	[ "$status" -ne 0 ]
 }

--- a/test/fixtures/block-mkdir.json
+++ b/test/fixtures/block-mkdir.json
@@ -1,0 +1,15 @@
+{
+    "defaultAction": "SCMP_ACT_ERRNO",
+    "syscalls": [
+        {
+            "names": [
+                "mkdir"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "args": [],
+            "comment": "",
+            "includes": {},
+            "excludes": {}
+        }
+    ]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,1 +1,2 @@
 ALPINE="docker.io/library/alpine:latest"
+BLOCK_MKDIR="./fixtures/block-mkdir.json"


### PR DESCRIPTION
The tool can now take an input file and expand upon the syscalls recorded in the input seccomp profile
I had to change the delimiter to `;` as `,` didn't work. There's one con to use this delimiter, you will have to wrap the annotation in `""`.

Interface:
```
sudo podman run --annotation io.containers.trace-syscall="if:/path/to/input.json;of:/path/to/output.json" IMAGE COMMAND
```

Fixes #10 