### PR TITLE
test-integration: check for root before executing tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ vendor:
 test-integration:
 	@echo
 	@echo "==> Running integration tests (must be run as root)"
+	./hack/check_root.sh
 	bats $(BATS_OPTS) test/
 
 

--- a/hack/check_root.sh
+++ b/hack/check_root.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if ! [ $(id -u) = 0 ]; then
+   echo "No root privileges.  Please run as root!"
+   exit 1
+fi


### PR DESCRIPTION
The integration tests require root privileges because we're running eBPF
programs.  To prevent users from running into this trap add an
additional root check before executing the integration tests.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>