### PR TITLE
modify Makefile for re-use in packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,24 @@ install.tools: .install.golangci-lint .install.md2man
 		   $(call go-get,github.com/cpuguy83/go-md2man); \
 	fi
 
-.PHONY: install
-install:
+.PHONY: install.docs-nobuild
+install.docs-nobuild:
+	$(MAKE) -C docs install-nobuild
+
+.PHONY: install.docs
+install.docs:
+	$(MAKE) -C docs install
+
+.PHONY: install-nobuild
+install-nobuild: install.docs-nobuild
 	install ${SELINUXOPT} -d -m 755 ${DESTDIR}$(HOOK_BIN_DIR)
 	install ${SELINUXOPT} -d -m 755 ${DESTDIR}$(HOOK_DIR)
 	install ${SELINUXOPT} -m 755 bin/oci-seccomp-bpf-hook ${DESTDIR}$(HOOK_BIN_DIR)
 	install ${SELINUXOPT} -m 644 oci-seccomp-bpf-hook.json ${DESTDIR}$(HOOK_DIR)
 	sed -i 's|HOOK_BIN_DIR|$(HOOK_BIN_DIR)|g' ${DESTDIR}$(HOOK_DIR)/oci-seccomp-bpf-hook.json
-	$(MAKE) -C docs install PREFIX=$(PREFIX)
+
+.PHONY: install
+install: docs install-nobuild
 
 clean: ## Clean artifacts
 	$(MAKE) -C docs clean

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
-PREFIX := /usr/local
-DATADIR := $(PREFIX)/share
-MANDIR := $(DATADIR)/man
+PREFIX ?= /usr/local
+DATADIR ?= $(PREFIX)/share
+MANDIR ?= $(DATADIR)/man
 GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
 
 docs: $(patsubst %.md,%.1,$(wildcard *.md))
@@ -8,10 +8,13 @@ docs: $(patsubst %.md,%.1,$(wildcard *.md))
 %.1: %.md
 	$(GOMD2MAN) -in $^ -out $@
 
-.PHONY: install
-install: docs
+.PHONY: install-nobuild
+install-nobuild:
 	install -d ${MANDIR}/man1
 	install -m 0644 oci-seccomp-bpf-hook*.1 ${MANDIR}/man1
+
+.PHONY: install
+install: docs install-nobuild
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This change will let the packager specify custom install locations and
avoid hitting the build target while running the install target.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@rhatdan PTAL