### PR TITLE
DESTDIR and PREFIX consistent in Makefiles

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,7 +125,7 @@ test_task:
     script:
         - $SCRIPT_BASE/setup.sh
         - make binary
-        - sudo make install
+        - sudo make PREFIX=/usr install
         - make test-unit
         - sh ./hack/enable-bpf.sh || true
         - sudo make test-integration

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
 	GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
 endif
 DESTDIR ?=
-PREFIX ?= /usr
+PREFIX ?= /usr/local
 SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo -Z)
 PROJECT := github.com/containers/oci-seccomp-bpf-hook
-HOOK_BIN_DIR ?= ${PREFIX}/libexec/oci/hooks.d
+HOOK_BIN_DIR ?= $(PREFIX)/libexec/oci/hooks.d
 ETCDIR ?= /etc
-HOOK_DIR ?= ${PREFIX}/share/containers/oci/hooks.d/
+HOOK_DIR ?= $(PREFIX)/share/containers/oci/hooks.d/
 VERSION ?= $(shell cat ./VERSION)
 
 # Can be used for local testing (e.g., to set filters)
@@ -34,7 +34,7 @@ endif
 
 define go-get
 	env GO111MODULE=off \
-		$(GO) get -u ${1}
+		$(GO) get -u $(1)
 endef
 
 .PHONY: all
@@ -46,7 +46,7 @@ docs:
 
 .PHONY: binary
 binary:
-	$(GO_BUILD) -mod=vendor -o bin/oci-seccomp-bpf-hook -ldflags "-X main.version=${VERSION}" $(PROJECT)
+	$(GO_BUILD) -mod=vendor -o bin/oci-seccomp-bpf-hook -ldflags "-X main.version=$(VERSION)" $(PROJECT)
 
 .PHONY: validate
 validate:
@@ -93,11 +93,11 @@ install.docs:
 
 .PHONY: install-nobuild
 install-nobuild: install.docs-nobuild
-	install ${SELINUXOPT} -d -m 755 ${DESTDIR}$(HOOK_BIN_DIR)
-	install ${SELINUXOPT} -d -m 755 ${DESTDIR}$(HOOK_DIR)
-	install ${SELINUXOPT} -m 755 bin/oci-seccomp-bpf-hook ${DESTDIR}$(HOOK_BIN_DIR)
-	install ${SELINUXOPT} -m 644 oci-seccomp-bpf-hook.json ${DESTDIR}$(HOOK_DIR)
-	sed -i 's|HOOK_BIN_DIR|$(HOOK_BIN_DIR)|g' ${DESTDIR}$(HOOK_DIR)/oci-seccomp-bpf-hook.json
+	install $(SELINUXOPT) -d -m 755 $(DESTDIR)$(HOOK_BIN_DIR)
+	install $(SELINUXOPT) -d -m 755 $(DESTDIR)$(HOOK_DIR)
+	install $(SELINUXOPT) -m 755 bin/oci-seccomp-bpf-hook $(DESTDIR)$(HOOK_BIN_DIR)
+	install $(SELINUXOPT) -m 644 oci-seccomp-bpf-hook.json $(DESTDIR)$(HOOK_DIR)
+	sed -i 's|HOOK_BIN_DIR|$(HOOK_BIN_DIR)|g' $(DESTDIR)$(HOOK_DIR)/oci-seccomp-bpf-hook.json
 
 .PHONY: install
 install: docs install-nobuild

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,4 @@
+DESTDIR ?=
 PREFIX ?= /usr/local
 DATADIR ?= $(PREFIX)/share
 MANDIR ?= $(DATADIR)/man
@@ -10,8 +11,8 @@ docs: $(patsubst %.md,%.1,$(wildcard *.md))
 
 .PHONY: install-nobuild
 install-nobuild:
-	install -d ${MANDIR}/man1
-	install -m 0644 oci-seccomp-bpf-hook*.1 ${MANDIR}/man1
+	install -d $(DESTDIR)$(MANDIR)/man1
+	install -m 0644 oci-seccomp-bpf-hook*.1 $(DESTDIR)$(MANDIR)/man1
 
 .PHONY: install
 install: docs install-nobuild


### PR DESCRIPTION
- Use DESTDIR var in docs/Makefile as well.
- install manpage to $(DESTDIR)$(MANDIR)
- Set PREFIX to /usr/local in the main Makefile.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@vrothberg @rhatdan PTAL, some more changes needed for packaging to reuse Makefile.