### PR TITLE
Fix issue #43: Renamed env variable VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PROJECT := github.com/containers/oci-seccomp-bpf-hook
 HOOK_BIN_DIR ?= $(PREFIX)/libexec/oci/hooks.d
 ETCDIR ?= /etc
 HOOK_DIR ?= $(PREFIX)/share/containers/oci/hooks.d/
-VERSION ?= $(shell cat ./VERSION)
+OSBH_VERSION ?= $(shell cat ./VERSION)
 
 # Can be used for local testing (e.g., to set filters)
 BATS_OPTS ?=
@@ -46,7 +46,7 @@ docs:
 
 .PHONY: binary
 binary:
-	$(GO_BUILD) -mod=vendor -o bin/oci-seccomp-bpf-hook -ldflags "-X main.version=$(VERSION)" $(PROJECT)
+	$(GO_BUILD) -mod=vendor -o bin/oci-seccomp-bpf-hook -ldflags "-X main.version=$(OSBH_VERSION)" $(PROJECT)
 
 .PHONY: validate
 validate:


### PR DESCRIPTION
Fix issue #43: Renamed env variable VERSION to OSBH_VERSION in Makefile to avoid potential conflict.
This prevented compilation on Fedora 32 Silverblue where the variable was set per default to 32.20200530.0 (Silverblue)