### PR TITLE
make sure `kheaders` are loaded

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,7 +127,6 @@ test_task:
         - make binary
         - sudo make PREFIX=/usr install
         - make test-unit
-        - sh ./hack/enable-bpf.sh || true
         - sudo make test-integration
 
     binaries_artifacts:

--- a/hack/enable-bpf.sh
+++ b/hack/enable-bpf.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# The Cirrus CI VM images have some setting that forbids us to run the hook.
-# While debugging, we found that after running some tools from `bpftool` we can
-# run the hook again.  For now, that's good enough but we need to check what's
-# going exactly.
-/usr/share/bcc/tools/trace probe


### PR DESCRIPTION
Make sure that the kheaders module is loaded.  The headers are required
for compiling the BPF program.

Also remove the hack in the CI that worked around this issue.  Credits
to Giuseppe Scrivano for tracking down that kheaders were missing.

Fixes: bugzilla.redhat.com/show_bug.cgi?id=1848078
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>