### PR TITLE
make loading kheaders non-fatal

### DIFF
--- a/oci-seccomp-bpf-hook.go
+++ b/oci-seccomp-bpf-hook.go
@@ -108,9 +108,9 @@ func modprobe(module string) error {
 // detachAndTrace re-executes the current executable to "fork" in go-ish way and
 // traces the provided PID.
 func detachAndTrace() error {
-	logrus.Info("Loading kheaders module")
+	logrus.Info("Trying to load `kheaders` module")
 	if err := modprobe("kheaders"); err != nil {
-		return errors.Wrap(err, "error loading kheaders module")
+		logrus.Infof("Loading `kheaders` failed, continuing in hope kernel headers reside on disk: %v", err)
 	}
 
 	// Read the State spec from stdin and unmarshal it.


### PR DESCRIPTION
The `kheaders` kernel module was introduced with Linux 5.2 and allows
for accessign kernel headers via the proc FS.  The target use case are
eBPF tools without requiring the headers to be stored on the file
systems but to ship them directly with the kernel.

While this enabled running the seccomp hook in new environments, we also
ran into issues on older kernel, for instance on RHEL.  Those systems
have the kernel headers on disk, so we don't need to load the `kheaders`
module.

To enable the hook on older systems, make the modprobe error non-fatal
and only log it but continue tracing with the expectation that the
kernel headers are accessible on disk, so we can compile the eBPF
tracer.

Fixes: bugzilla.redhat.com/show_bug.cgi?id=1857606
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>