### PR TITLE
README: link to the enable sysadmin article

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ sudo podman run --annotation io.containers.trace-syscall="if:[absolute path to t
 ```
 
 The profile will be created at the output path provided to the annotation. Providing `of:` is mandatory, while `if:` is optional. An input file can be used to create a baseline and newly recorded syscalls will be added to the set and written to the output. If a syscall is blocked in the base profile, then it will remain blocked in the output file even if it is recorded while tracing.
+
+Please refer to an article on [Enable Sysadmin](https://www.redhat.com/sysadmin/container-security-seccomp) for more details.


### PR DESCRIPTION
The article [1] gives some nice background on the history of the hook
and further details that we do not need repeat here.

[1] https://www.redhat.com/sysadmin/container-security-seccomp

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>