### PR TITLE
Make annotation pattern match more strictly

### DIFF
--- a/oci-seccomp-bpf-hook.json
+++ b/oci-seccomp-bpf-hook.json
@@ -9,7 +9,7 @@
     },
     "when": {
         "annotations": {
-            "io.containers.trace-syscall": ".*"
+            "^io\\.containers\\.trace-syscall$": ".*"
         }
     },
     "stages": [


### PR DESCRIPTION
The annotation name is supposed to be a regex. Add anchors and escape
characters to use and exact match for the annotation.

Signed-off-by: Ralf Haferkamp <rhafer@suse.com>