### PR TITLE
Test suite: minimal tweaks for gating environment

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,2 +1,5 @@
-ALPINE="docker.io/library/alpine:latest"
-BLOCK_MKDIR=$(realpath ./test/fixtures/block-mkdir.json)
+ALPINE="quay.io/libpod/alpine:latest"
+BLOCK_MKDIR=$(realpath $(dirname ${BASH_SOURCE[0]})/fixtures/block-mkdir.json)
+
+# Hostname that should be ping'able from any environment in which we run tests
+PINGABLE_HOST=github.com


### PR DESCRIPTION
In preparation for creating a -tests subpackage for use in
Fedora gating tests:

 * Use alpine image from quay.io, to avoid docker.io throttling
 * Find block-mkdir.json relative to helpers.bash file, not source dir
 * Skip the version test, it can't work in an rpm environment
 * Use github.com as a ping destination host (google.com is
   unreachable from one of our CI environments).

Because my editor demands it and it's proper practice:

 * Clean up trailing whitespace

Signed-off-by: Ed Santiago <santiago@redhat.com>
