### PR TITLE
Do not record empty syscall names

### DIFF
--- a/oci-seccomp-bpf-hook.go
+++ b/oci-seccomp-bpf-hook.go
@@ -300,6 +300,7 @@ func runBPFSource(pid int, profilePath string, inputFile string) (finalErr error
 		name, err := syscallIDtoName(e.ID)
 		if err != nil {
 			logrus.Errorf("error getting the name for syscall ID %d", e.ID)
+			continue
 		}
 		syscalls[name]++
 	}


### PR DESCRIPTION
If a syscall name cannot be retrieved, then we should not add it to the map of found syscalls to omit writing `""` to the profile.
