### PR TITLE
Make the test work w/ non-default hooks directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test-integration:
 	@echo
 	@echo "==> Running integration tests (must be run as root)"
 	./hack/check_root.sh
-	bats $(BATS_OPTS) test/
+	env HOOKS_DIR=$(HOOK_DIR) bats $(BATS_OPTS) test/
 
 .PHONY: test-unit
 test-unit:

--- a/test/00-simple.bats
+++ b/test/00-simple.bats
@@ -31,7 +31,7 @@ load helpers
 	tmpFile=$(mktemp)
 	echo "Temporary file: ${tmpFile}"
 
-	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
+	run podman run --net=host $HOOKS_DIR_OPT --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 	# sleep two seconds to let the hook finish writing the file
@@ -49,7 +49,7 @@ load helpers
 	tmpFile=$(mktemp)
 	echo "Temporary file: ${tmpFile}"
 
-	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
+	run podman run --net=host $HOOKS_DIR_OPT --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 	# sleep two seconds to let the hook finish writing the file
@@ -71,7 +71,7 @@ load helpers
 	tmpFile=$(mktemp)
 	echo "Temporary file: ${tmpFile}"
 
-	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
+	run podman run --net=host $HOOKS_DIR_OPT --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 	# sleep two seconds to let the hook finish writing the file
@@ -100,7 +100,7 @@ load helpers
 	echo "Temporary file 1: ${tmpFile1}"
 	echo "Temporary file 2: ${tmpFile2}"
 
-	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile1} ${ALPINE} ls /
+	run podman run --net=host $HOOKS_DIR_OPT --annotation io.containers.trace-syscall=of:${tmpFile1} ${ALPINE} ls /
 	[ "$status" -eq 0 ]
 	# sleep two seconds to let the hook finish writing the file
 	sleep 2
@@ -113,7 +113,7 @@ load helpers
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -ne 0 ]
 
-	run podman run --net=host --annotation io.containers.trace-syscall="if:${tmpFile1};of:${tmpFile2}" ${ALPINE} ping -c3 $PINGABLE_HOST
+	run podman run --net=host $HOOKS_DIR_OPT --annotation io.containers.trace-syscall="if:${tmpFile1};of:${tmpFile2}" ${ALPINE} ping -c3 $PINGABLE_HOST
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 	sleep 2	# sleep two seconds to let the hook finish writing the file
@@ -138,7 +138,7 @@ load helpers
 	tmpFile=$(mktemp)
 	echo "Temporary file : ${tmpFile}"
 
-	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} mkdir /foo
+	run podman run --net=host $HOOKS_DIR_OPT --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} mkdir /foo
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 	# sleep two seconds to let the hook finish writing the file
@@ -152,7 +152,7 @@ load helpers
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 
-	run podman run --net=host --annotation io.containers.trace-syscall="if:${BLOCK_MKDIR};of:${tmpFile}" ${ALPINE} mkdir /foo
+	run podman run --net=host $HOOKS_DIR_OPT --annotation io.containers.trace-syscall="if:${BLOCK_MKDIR};of:${tmpFile}" ${ALPINE} mkdir /foo
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 	# sleep two seconds to let the hook finish writing the file

--- a/test/01-syslog.bats
+++ b/test/01-syslog.bats
@@ -11,7 +11,7 @@ load helpers
 	tmpFile=$(mktemp)
 	echo "Temporary file: ${tmpFile}"
 
-	run podman run --net=host --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
+	run podman run --net=host $HOOKS_DIR_OPT --annotation io.containers.trace-syscall=of:${tmpFile} ${ALPINE} ls
 	echo "Podman output: ${lines[*]}"
 	[ "$status" -eq 0 ]
 	# sleep two seconds to let the hook finish writing the file

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -3,3 +3,9 @@ BLOCK_MKDIR=$(realpath $(dirname ${BASH_SOURCE[0]})/fixtures/block-mkdir.json)
 
 # Hostname that should be ping'able from any environment in which we run tests
 PINGABLE_HOST=github.com
+
+# Without giving HOOKS_DIR, the option will not appear, which avoids writing
+# default hooks directory in the command.
+if [ ! -z $HOOKS_DIR ]; then
+	HOOKS_DIR_OPT="--hooks-dir=$HOOKS_DIR"
+fi


### PR DESCRIPTION
By default the hook is expected to locate in
`/usr/share/containers/oci/hooks.d`
However, "make install" uses the prefix `/usr/local` as default. This change enables "make test-integration" to work in this situation.

It does not affect the test in the packaging where the hook is installed in the default directory.