### PR TITLE
hook: profile syscall arguments to generate tighter socket seccomp rules

### DIFF
--- a/ebpf.go
+++ b/ebpf.go
@@ -10,6 +10,10 @@ type event struct {
 	Command [16]byte
 	// Stops tracing syscalls if true
 	StopTracing bool
+	// HasArg0 is true for syscalls whose first argument is being profiled.
+	HasArg0 bool
+	_       [2]byte // padding to align Arg0
+	Arg0    uint32
 }
 
 // the source is a bpf program compiled at runtime. Some macro's like
@@ -30,6 +34,10 @@ BPF_HASH(parent_namespace, u64, u64);
 
 BPF_HASH(seen_syscalls, int, u64);
 
+// seen_args deduplicates events for arg-tracked syscalls.
+// Key is (syscall_id << 32 | arg0) so each (syscall, arg0) pair is sent once.
+BPF_HASH(seen_args, u64, u64);
+
 // Opens a custom BPF table to push data to user space via perf ring buffer
 BPF_PERF_OUTPUT(events);
 
@@ -43,6 +51,12 @@ struct syscall_data {
     char comm[16];
     // Stops tracing syscalls if true
     bool stopTracing;
+    // True if the syscall has a 1st positional argument
+    bool hasArg0;
+    // padding
+    u8 _pad[2];
+    // The value of the first positional argument if any
+    u32 arg0;
 };
 
 // enter_trace is attached to raw_syscalls:sys_enter.  It records
@@ -102,6 +116,21 @@ int enter_trace(struct tracepoint__raw_syscalls__sys_enter* args)
 
         if (prctl_seen == NULL)
             return 0;
+
+        // Arg-tracked syscalls: dedup on (id, arg0) and carry arg0 in the event
+        // so the profiler can emit one allow rule per observed argument value.
+        if (id == __NR_socket) {
+            u32 arg0_val = (u32)args->args[0];
+            u64 arg_key = ((u64)(u32)id << 32) | arg0_val;
+            if (seen_args.lookup(&arg_key) != NULL)
+                return 0;
+            data.hasArg0 = true;
+            data.arg0 = arg0_val;
+            events.perf_submit(args, &data, sizeof(data));
+            u64 one = 1;
+            seen_args.update(&arg_key, &one);
+            return 0;
+        }
     }
 
     data.stopTracing = false;

--- a/oci-seccomp-bpf-hook.go
+++ b/oci-seccomp-bpf-hook.go
@@ -50,6 +50,14 @@ var (
 	errInvalidAnnotation = errors.New("invalid annotation")
 )
 
+// argTrackedSyscalls maps syscall names to the argument index to capture.
+// For these syscalls the profiler emits one allow rule per observed argument
+// value (using SCMP_CMP_EQ) instead of a single unconditional allow.
+// The eBPF program must have a corresponding branch for each entry.
+var argTrackedSyscalls = map[string]int{
+	"socket": 0,
+}
+
 func main() {
 	// To facilitate debugging of the hook, write all logs to the syslog,
 	// so we can inspect its output via `journalctl`.
@@ -224,6 +232,7 @@ func runBPFSource(pid int, profilePath string, inputFile string) (finalErr error
 	}()
 
 	syscalls := make(map[string]int, 303)
+	syscallArgs := make(map[string]map[uint32]struct{})
 	src := strings.ReplaceAll(source, "$PARENT_PID", strconv.Itoa(pid))
 	m := bcc.NewModule(src, []string{})
 	defer m.Close()
@@ -308,13 +317,19 @@ func runBPFSource(pid int, profilePath string, inputFile string) (finalErr error
 			continue
 		}
 		syscalls[name]++
+		if _, tracked := argTrackedSyscalls[name]; tracked && e.HasArg0 {
+			if syscallArgs[name] == nil {
+				syscallArgs[name] = make(map[uint32]struct{})
+			}
+			syscallArgs[name][e.Arg0] = struct{}{}
+		}
 	}
 
 	logrus.Info("PerfMap Stop")
 	go perfMap.Stop()
 
 	logrus.Infof("Writing seccomp profile to %q", profilePath)
-	if err := generateProfile(syscalls, profilePath, inputFile); err != nil {
+	if err := generateProfile(syscalls, syscallArgs, profilePath, inputFile); err != nil {
 		return fmt.Errorf("error generating final seccomp profile: %v", err)
 	}
 	return nil
@@ -322,7 +337,7 @@ func runBPFSource(pid int, profilePath string, inputFile string) (finalErr error
 
 // generateProfile generates the seccomp profile from the specified syscalls and
 // the input file.
-func generateProfile(syscalls map[string]int, profilePath string, inputFile string) error {
+func generateProfile(syscalls map[string]int, syscallArgs map[string]map[uint32]struct{}, profilePath string, inputFile string) error {
 	outputProfile := types.Seccomp{}
 	inputProfile := types.Seccomp{}
 
@@ -337,10 +352,12 @@ func generateProfile(syscalls map[string]int, profilePath string, inputFile stri
 		}
 	}
 
+	// Unconditional allows for regular syscalls.
+	// Syscalls with per-value argument rules (in syscallArgs) are handled separately below.
 	var names []string
-	for syscallName, syscallID := range syscalls {
-		if syscallID > 0 {
-			if !syscallInProfile(&inputProfile, syscallName) {
+	for syscallName, count := range syscalls {
+		if count > 0 && !syscallInProfile(&inputProfile, syscallName) {
+			if _, hasArgRules := syscallArgs[syscallName]; !hasArgRules {
 				names = append(names, syscallName)
 			}
 		}
@@ -359,6 +376,32 @@ func generateProfile(syscalls map[string]int, profilePath string, inputFile stri
 		Names:  names,
 		Args:   []*types.Arg{},
 	})
+
+	// Per-value allow rules for arg-tracked syscalls: one rule per observed argument value.
+	for syscallName, argVals := range syscallArgs {
+		if syscallInProfile(&inputProfile, syscallName) {
+			continue
+		}
+		argIdx := uint(argTrackedSyscalls[syscallName])
+		vals := make([]uint32, 0, len(argVals))
+		for v := range argVals {
+			vals = append(vals, v)
+		}
+		sort.Slice(vals, func(i, j int) bool { return vals[i] < vals[j] })
+		for _, v := range vals {
+			outputProfile.Syscalls = append(outputProfile.Syscalls, &types.Syscall{
+				Action: types.ActAllow,
+				Names:  []string{syscallName},
+				Args: []*types.Arg{
+					{
+						Index: argIdx,
+						Value: uint64(v),
+						Op:    types.OpEqualTo,
+					},
+				},
+			})
+		}
+	}
 
 	sJSON, err := json.Marshal(outputProfile)
 	if err != nil {


### PR DESCRIPTION
The hook previously emitted an unconditional SCMP_ACT_ALLOW for every observed syscall. For syscalls whose first argument meaningfully narrows the attack surface, this is too permissive: a container that only uses AF_INET and AF_INET6 sockets should not implicitly allow AF_ALG, which has been the entry point for kernel vulnerabilities such as CVE-2026-31431.

This commit introduces per-argument profiling for a configurable set of syscalls. For these syscalls the eBPF program deduplicates on (syscall, arg0) instead of just the syscall number, and the Go side emits one SCMP_CMP_EQ allow rule per observed argument value rather than a single unconditional allow.

socket(2) is the first enabled syscall, profiling the address-family argument (arg0). A container that calls socket(AF_INET, ...) and socket(AF_INET6, ...) will now produce:

  {"names":["socket"],"action":"SCMP_ACT_ALLOW",
   "args":[{"index":0,"value":2,"op":"SCMP_CMP_EQ"}]}   // AF_INET
  {"names":["socket"],"action":"SCMP_ACT_ALLOW",
   "args":[{"index":0,"value":10,"op":"SCMP_CMP_EQ"}]}  // AF_INET6

instead of a bare unconditional allow that would also permit AF_ALG, AF_PACKET, AF_VSOCK, and other families the container never uses.

Adding further syscalls to the table requires one entry in argTrackedSyscalls (Go) and one if-branch in enter_trace (eBPF).